### PR TITLE
Fix for build error in Defold 1.9.4

### DIFF
--- a/sharp_sprite/rgss/fonts/font-fnt.fp
+++ b/sharp_sprite/rgss/fonts/font-fnt.fp
@@ -15,17 +15,17 @@ uniform mediump sampler2D texture_sampler;
 // Rotated grid UV offsets
 const mediump vec2 rgss_uv_offsets = vec2(0.125, 0.375);
 
-mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
+mediump vec4 rgss_tex2D(highp vec2 uv)
 {
     // Per pixel partial derivatives
     mediump vec2 dx = dFdx(uv);
     mediump vec2 dy = dFdy(uv);
 
     // Supersampled using 2x2 rotated grid
-    mediump vec4 col = texture2D(tex, vec2(uv + rgss_uv_offsets.x * dx + rgss_uv_offsets.y * dy));
-    col += texture2D(tex, vec2(uv - rgss_uv_offsets.x * dx - rgss_uv_offsets.y * dy));
-    col += texture2D(tex, vec2(uv + rgss_uv_offsets.y * dx - rgss_uv_offsets.x * dy));
-    col += texture2D(tex, vec2(uv - rgss_uv_offsets.y * dx + rgss_uv_offsets.x * dy));
+    mediump vec4 col = texture2D(texture_sampler, vec2(uv + rgss_uv_offsets.x * dx + rgss_uv_offsets.y * dy));
+    col += texture2D(texture_sampler, vec2(uv - rgss_uv_offsets.x * dx - rgss_uv_offsets.y * dy));
+    col += texture2D(texture_sampler, vec2(uv + rgss_uv_offsets.y * dx - rgss_uv_offsets.x * dy));
+    col += texture2D(texture_sampler, vec2(uv - rgss_uv_offsets.y * dx + rgss_uv_offsets.x * dy));
 
     col *= 0.25;
 
@@ -33,13 +33,13 @@ mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
 }
 #else
 // A fallback in the case of derivatives lack
-mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
+mediump vec4 rgss_tex2D(highp vec2 uv)
 {
-    return texture2D(tex, uv);
+    return texture2D(texture_sampler, uv);
 }
 #endif
 
 void main()
 {
-    gl_FragColor = rgss_tex2D(texture_sampler, var_texcoord0.xy) * var_face_color * var_face_color.a;
+    gl_FragColor = rgss_tex2D(var_texcoord0.xy) * var_face_color * var_face_color.a;
 }

--- a/sharp_sprite/rgss/fonts/font-singlelayer.fp
+++ b/sharp_sprite/rgss/fonts/font-singlelayer.fp
@@ -16,17 +16,17 @@ uniform mediump sampler2D texture_sampler;
 // Rotated grid UV offsets
 const mediump vec2 rgss_uv_offsets = vec2(0.125, 0.375);
 
-mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
+mediump vec4 rgss_tex2D(highp vec2 uv)
 {
     // Per pixel partial derivatives
     mediump vec2 dx = dFdx(uv);
     mediump vec2 dy = dFdy(uv);
 
     // Supersampled using 2x2 rotated grid
-    mediump vec4 col = texture2D(tex, vec2(uv + rgss_uv_offsets.x * dx + rgss_uv_offsets.y * dy));
-    col += texture2D(tex, vec2(uv - rgss_uv_offsets.x * dx - rgss_uv_offsets.y * dy));
-    col += texture2D(tex, vec2(uv + rgss_uv_offsets.y * dx - rgss_uv_offsets.x * dy));
-    col += texture2D(tex, vec2(uv - rgss_uv_offsets.y * dx + rgss_uv_offsets.x * dy));
+    mediump vec4 col = texture2D(texture_sampler, vec2(uv + rgss_uv_offsets.x * dx + rgss_uv_offsets.y * dy));
+    col += texture2D(texture_sampler, vec2(uv - rgss_uv_offsets.x * dx - rgss_uv_offsets.y * dy));
+    col += texture2D(texture_sampler, vec2(uv + rgss_uv_offsets.y * dx - rgss_uv_offsets.x * dy));
+    col += texture2D(texture_sampler, vec2(uv - rgss_uv_offsets.y * dx + rgss_uv_offsets.x * dy));
 
     col *= 0.25;
 
@@ -34,14 +34,14 @@ mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
 }
 #else
 // A fallback in the case of derivatives lack
-mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
+mediump vec4 rgss_tex2D(highp vec2 uv)
 {
-    return texture2D(tex, uv);
+    return texture2D(texture_sampler, uv);
 }
 #endif
 
 void main()
 {
-    lowp vec2 t  = rgss_tex2D(texture_sampler, var_texcoord0.xy).xy;
+    lowp vec2 t  = rgss_tex2D(var_texcoord0.xy).xy;
     gl_FragColor = vec4(var_face_color.xyz, 1.0) * t.x * var_face_color.w + vec4(var_outline_color.xyz * t.y * var_outline_color.w, t.y * var_outline_color.w) * (1.0 - t.x);
 }

--- a/sharp_sprite/rgss/fonts/font.fp
+++ b/sharp_sprite/rgss/fonts/font.fp
@@ -18,17 +18,17 @@ uniform mediump sampler2D texture_sampler;
 // Rotated grid UV offsets
 const mediump vec2 rgss_uv_offsets = vec2(0.125, 0.375);
 
-mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
+mediump vec4 rgss_tex2D(highp vec2 uv)
 {
     // Per pixel partial derivatives
     mediump vec2 dx = dFdx(uv);
     mediump vec2 dy = dFdy(uv);
 
     // Supersampled using 2x2 rotated grid
-    mediump vec4 col = texture2D(tex, vec2(uv + rgss_uv_offsets.x * dx + rgss_uv_offsets.y * dy));
-    col += texture2D(tex, vec2(uv - rgss_uv_offsets.x * dx - rgss_uv_offsets.y * dy));
-    col += texture2D(tex, vec2(uv + rgss_uv_offsets.y * dx - rgss_uv_offsets.x * dy));
-    col += texture2D(tex, vec2(uv - rgss_uv_offsets.y * dx + rgss_uv_offsets.x * dy));
+    mediump vec4 col = texture2D(texture_sampler, vec2(uv + rgss_uv_offsets.x * dx + rgss_uv_offsets.y * dy));
+    col += texture2D(texture_sampler, vec2(uv - rgss_uv_offsets.x * dx - rgss_uv_offsets.y * dy));
+    col += texture2D(texture_sampler, vec2(uv + rgss_uv_offsets.y * dx - rgss_uv_offsets.x * dy));
+    col += texture2D(texture_sampler, vec2(uv - rgss_uv_offsets.y * dx + rgss_uv_offsets.x * dy));
 
     col *= 0.25;
 
@@ -36,16 +36,16 @@ mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
 }
 #else
 // A fallback in the case of derivatives lack
-mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
+mediump vec4 rgss_tex2D(highp vec2 uv)
 {
-    return texture2D(tex, uv);
+    return texture2D(texture_sampler, uv);
 }
 #endif
 
 void main()
 {
     lowp float is_single_layer = var_layer_mask.a;
-    lowp vec3 t                = rgss_tex2D(texture_sampler, var_texcoord0.xy).xyz;
+    lowp vec3 t                = rgss_tex2D(var_texcoord0.xy).xyz;
     lowp float face_alpha      = t.x * var_face_color.w;
     gl_FragColor      = (var_layer_mask.x * face_alpha * vec4(var_face_color.xyz, 1.0) +
         var_layer_mask.y * vec4(var_outline_color.xyz, 1.0) * var_outline_color.w * t.y * (1.0 - face_alpha * is_single_layer) +

--- a/sharp_sprite/rgss/materials/gui.fp
+++ b/sharp_sprite/rgss/materials/gui.fp
@@ -15,17 +15,17 @@ uniform mediump sampler2D texture_sampler;
 // Rotated grid UV offsets
 const mediump vec2 rgss_uv_offsets = vec2(0.125, 0.375);
 
-mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
+mediump vec4 rgss_tex2D(highp vec2 uv)
 {
     // Per pixel partial derivatives
     mediump vec2 dx = dFdx(uv);
     mediump vec2 dy = dFdy(uv);
 
     // Supersampled using 2x2 rotated grid
-    mediump vec4 col = texture2D(tex, vec2(uv + rgss_uv_offsets.x * dx + rgss_uv_offsets.y * dy));
-    col += texture2D(tex, vec2(uv - rgss_uv_offsets.x * dx - rgss_uv_offsets.y * dy));
-    col += texture2D(tex, vec2(uv + rgss_uv_offsets.y * dx - rgss_uv_offsets.x * dy));
-    col += texture2D(tex, vec2(uv - rgss_uv_offsets.y * dx + rgss_uv_offsets.x * dy));
+    mediump vec4 col = texture2D(texture_sampler, vec2(uv + rgss_uv_offsets.x * dx + rgss_uv_offsets.y * dy));
+    col += texture2D(texture_sampler, vec2(uv - rgss_uv_offsets.x * dx - rgss_uv_offsets.y * dy));
+    col += texture2D(texture_sampler, vec2(uv + rgss_uv_offsets.y * dx - rgss_uv_offsets.x * dy));
+    col += texture2D(texture_sampler, vec2(uv - rgss_uv_offsets.y * dx + rgss_uv_offsets.x * dy));
 
     col *= 0.25;
 
@@ -33,14 +33,14 @@ mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
 }
 #else
 // A fallback in the case of derivatives lack
-mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
+mediump vec4 rgss_tex2D(highp vec2 uv)
 {
-    return texture2D(tex, uv);
+    return texture2D(texture_sampler, uv);
 }
 #endif
 
 void main()
 {
-    mediump vec4 tex = rgss_tex2D(texture_sampler, var_texcoord0.xy);
+    mediump vec4 tex = rgss_tex2D(var_texcoord0.xy);
     gl_FragColor = tex * var_color;
 }

--- a/sharp_sprite/rgss/materials/particlefx.fp
+++ b/sharp_sprite/rgss/materials/particlefx.fp
@@ -16,17 +16,17 @@ uniform mediump vec4 tint;
 // Rotated grid UV offsets
 const mediump vec2 rgss_uv_offsets = vec2(0.125, 0.375);
 
-mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
+mediump vec4 rgss_tex2D(highp vec2 uv)
 {
     // Per pixel partial derivatives
     mediump vec2 dx = dFdx(uv);
     mediump vec2 dy = dFdy(uv);
 
     // Supersampled using 2x2 rotated grid
-    mediump vec4 col = texture2D(tex, vec2(uv + rgss_uv_offsets.x * dx + rgss_uv_offsets.y * dy));
-    col += texture2D(tex, vec2(uv - rgss_uv_offsets.x * dx - rgss_uv_offsets.y * dy));
-    col += texture2D(tex, vec2(uv + rgss_uv_offsets.y * dx - rgss_uv_offsets.x * dy));
-    col += texture2D(tex, vec2(uv - rgss_uv_offsets.y * dx + rgss_uv_offsets.x * dy));
+    mediump vec4 col = texture2D(texture_sampler, vec2(uv + rgss_uv_offsets.x * dx + rgss_uv_offsets.y * dy));
+    col += texture2D(texture_sampler, vec2(uv - rgss_uv_offsets.x * dx - rgss_uv_offsets.y * dy));
+    col += texture2D(texture_sampler, vec2(uv + rgss_uv_offsets.y * dx - rgss_uv_offsets.x * dy));
+    col += texture2D(texture_sampler, vec2(uv - rgss_uv_offsets.y * dx + rgss_uv_offsets.x * dy));
 
     col *= 0.25;
 
@@ -34,9 +34,9 @@ mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
 }
 #else
 // A fallback in the case of derivatives lack
-mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
+mediump vec4 rgss_tex2D(highp vec2 uv)
 {
-    return texture2D(tex, uv);
+    return texture2D(texture_sampler, uv);
 }
 #endif
 
@@ -45,5 +45,5 @@ void main()
     // Pre-multiply alpha since all runtime textures already are
     mediump vec4 tint_pm = vec4(tint.xyz * tint.w, tint.w);
     // var_color is vertex color from the particle system, pre-multiplied in vertex program
-    gl_FragColor = rgss_tex2D(texture_sampler, var_texcoord0.xy) * var_color * tint_pm;
+    gl_FragColor = rgss_tex2D(var_texcoord0.xy) * var_color * tint_pm;
 }

--- a/sharp_sprite/rgss/materials/spine.fp
+++ b/sharp_sprite/rgss/materials/spine.fp
@@ -16,17 +16,17 @@ uniform mediump vec4 tint;
 // Rotated grid UV offsets
 const mediump vec2 rgss_uv_offsets = vec2(0.125, 0.375);
 
-mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
+mediump vec4 rgss_tex2D(highp vec2 uv)
 {
     // Per pixel partial derivatives
     mediump vec2 dx = dFdx(uv);
     mediump vec2 dy = dFdy(uv);
 
     // Supersampled using 2x2 rotated grid
-    mediump vec4 col = texture2D(tex, vec2(uv + rgss_uv_offsets.x * dx + rgss_uv_offsets.y * dy));
-    col += texture2D(tex, vec2(uv - rgss_uv_offsets.x * dx - rgss_uv_offsets.y * dy));
-    col += texture2D(tex, vec2(uv + rgss_uv_offsets.y * dx - rgss_uv_offsets.x * dy));
-    col += texture2D(tex, vec2(uv - rgss_uv_offsets.y * dx + rgss_uv_offsets.x * dy));
+    mediump vec4 col = texture2D(texture_sampler, vec2(uv + rgss_uv_offsets.x * dx + rgss_uv_offsets.y * dy));
+    col += texture2D(texture_sampler, vec2(uv - rgss_uv_offsets.x * dx - rgss_uv_offsets.y * dy));
+    col += texture2D(texture_sampler, vec2(uv + rgss_uv_offsets.y * dx - rgss_uv_offsets.x * dy));
+    col += texture2D(texture_sampler, vec2(uv - rgss_uv_offsets.y * dx + rgss_uv_offsets.x * dy));
 
     col *= 0.25;
 
@@ -34,9 +34,9 @@ mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
 }
 #else
 // A fallback in the case of derivatives lack
-mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
+mediump vec4 rgss_tex2D(highp vec2 uv)
 {
-    return texture2D(tex, uv);
+    return texture2D(texture_sampler, uv);
 }
 #endif
 
@@ -45,5 +45,5 @@ void main()
     // Pre-multiply alpha since var_color and all runtime textures already are
     mediump vec4 tint_pm = vec4(tint.xyz * tint.w, tint.w);
     mediump vec4 color_pm = var_color * tint_pm;
-    gl_FragColor = rgss_tex2D(texture_sampler, var_texcoord0.xy) * color_pm;
+    gl_FragColor = rgss_tex2D(var_texcoord0.xy) * color_pm;
 }

--- a/sharp_sprite/rgss/materials/sprite.fp
+++ b/sharp_sprite/rgss/materials/sprite.fp
@@ -15,17 +15,17 @@ uniform mediump vec4 tint;
 // Rotated grid UV offsets
 const mediump vec2 rgss_uv_offsets = vec2(0.125, 0.375);
 
-mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
+mediump vec4 rgss_tex2D(highp vec2 uv)
 {
     // Per pixel partial derivatives
     mediump vec2 dx = dFdx(uv);
     mediump vec2 dy = dFdy(uv);
 
     // Supersampled using 2x2 rotated grid
-    mediump vec4 col = texture2D(tex, vec2(uv + rgss_uv_offsets.x * dx + rgss_uv_offsets.y * dy));
-    col += texture2D(tex, vec2(uv - rgss_uv_offsets.x * dx - rgss_uv_offsets.y * dy));
-    col += texture2D(tex, vec2(uv + rgss_uv_offsets.y * dx - rgss_uv_offsets.x * dy));
-    col += texture2D(tex, vec2(uv - rgss_uv_offsets.y * dx + rgss_uv_offsets.x * dy));
+    mediump vec4 col = texture2D(texture_sampler, vec2(uv + rgss_uv_offsets.x * dx + rgss_uv_offsets.y * dy));
+    col += texture2D(texture_sampler, vec2(uv - rgss_uv_offsets.x * dx - rgss_uv_offsets.y * dy));
+    col += texture2D(texture_sampler, vec2(uv + rgss_uv_offsets.y * dx - rgss_uv_offsets.x * dy));
+    col += texture2D(texture_sampler, vec2(uv - rgss_uv_offsets.y * dx + rgss_uv_offsets.x * dy));
 
     col *= 0.25;
 
@@ -33,9 +33,9 @@ mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
 }
 #else
 // A fallback in the case of derivatives lack
-mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
+mediump vec4 rgss_tex2D(highp vec2 uv)
 {
-    return texture2D(tex, uv);
+    return texture2D(texture_sampler, uv);
 }
 #endif
 
@@ -43,5 +43,5 @@ void main()
 {
     // Pre-multiply alpha since all runtime textures already are
     mediump vec4 tint_pm = vec4(tint.xyz * tint.w, tint.w);
-    gl_FragColor = rgss_tex2D(texture_sampler, var_texcoord0.xy) * tint_pm;
+    gl_FragColor = rgss_tex2D(var_texcoord0.xy) * tint_pm;
 }

--- a/sharp_sprite/rgss/materials/tile_map.fp
+++ b/sharp_sprite/rgss/materials/tile_map.fp
@@ -15,17 +15,17 @@ uniform mediump vec4 tint;
 // Rotated grid UV offsets
 const mediump vec2 rgss_uv_offsets = vec2(0.125, 0.375);
 
-mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
+mediump vec4 rgss_tex2D(highp vec2 uv)
 {
     // Per pixel partial derivatives
     mediump vec2 dx = dFdx(uv);
     mediump vec2 dy = dFdy(uv);
 
     // Supersampled using 2x2 rotated grid
-    mediump vec4 col = texture2D(tex, vec2(uv + rgss_uv_offsets.x * dx + rgss_uv_offsets.y * dy));
-    col += texture2D(tex, vec2(uv - rgss_uv_offsets.x * dx - rgss_uv_offsets.y * dy));
-    col += texture2D(tex, vec2(uv + rgss_uv_offsets.y * dx - rgss_uv_offsets.x * dy));
-    col += texture2D(tex, vec2(uv - rgss_uv_offsets.y * dx + rgss_uv_offsets.x * dy));
+    mediump vec4 col = texture2D(texture_sampler, vec2(uv + rgss_uv_offsets.x * dx + rgss_uv_offsets.y * dy));
+    col += texture2D(texture_sampler, vec2(uv - rgss_uv_offsets.x * dx - rgss_uv_offsets.y * dy));
+    col += texture2D(texture_sampler, vec2(uv + rgss_uv_offsets.y * dx - rgss_uv_offsets.x * dy));
+    col += texture2D(texture_sampler, vec2(uv - rgss_uv_offsets.y * dx + rgss_uv_offsets.x * dy));
 
     col *= 0.25;
 
@@ -33,9 +33,9 @@ mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
 }
 #else
 // A fallback in the case of derivatives lack
-mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
+mediump vec4 rgss_tex2D(highp vec2 uv)
 {
-    return texture2D(tex, uv);
+    return texture2D(texture_sampler, uv);
 }
 #endif
 
@@ -43,5 +43,5 @@ void main()
 {
     // Pre-multiply alpha since all runtime textures already are
     mediump vec4 tint_pm = vec4(tint.xyz * tint.w, tint.w);
-    gl_FragColor = rgss_tex2D(texture_sampler, var_texcoord0.xy) * tint_pm;
+    gl_FragColor = rgss_tex2D(var_texcoord0.xy) * tint_pm;
 }

--- a/sharp_sprite/rgss_bias/materials/gui.fp
+++ b/sharp_sprite/rgss_bias/materials/gui.fp
@@ -15,17 +15,17 @@ uniform mediump sampler2D texture_sampler;
 // Rotated grid UV offsets
 const mediump vec2 rgss_uv_offsets = vec2(0.125, 0.375);
 
-mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
+mediump vec4 rgss_tex2D(highp vec2 uv)
 {
     // Per pixel partial derivatives
     mediump vec2 dx = dFdx(uv);
     mediump vec2 dy = dFdy(uv);
 
     // Supersampled using 2x2 rotated grid
-    mediump vec4 col = texture2D(tex, vec2(uv + rgss_uv_offsets.x * dx + rgss_uv_offsets.y * dy), -1.0);
-    col += texture2D(tex, vec2(uv - rgss_uv_offsets.x * dx - rgss_uv_offsets.y * dy), -1.0);
-    col += texture2D(tex, vec2(uv + rgss_uv_offsets.y * dx - rgss_uv_offsets.x * dy), -1.0);
-    col += texture2D(tex, vec2(uv - rgss_uv_offsets.y * dx + rgss_uv_offsets.x * dy), -1.0);
+    mediump vec4 col = texture2D(texture_sampler, vec2(uv + rgss_uv_offsets.x * dx + rgss_uv_offsets.y * dy), -1.0);
+    col += texture2D(texture_sampler, vec2(uv - rgss_uv_offsets.x * dx - rgss_uv_offsets.y * dy), -1.0);
+    col += texture2D(texture_sampler, vec2(uv + rgss_uv_offsets.y * dx - rgss_uv_offsets.x * dy), -1.0);
+    col += texture2D(texture_sampler, vec2(uv - rgss_uv_offsets.y * dx + rgss_uv_offsets.x * dy), -1.0);
 
     col *= 0.25;
 
@@ -33,14 +33,14 @@ mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
 }
 #else
 // A fallback in the case of derivatives lack
-mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
+mediump vec4 rgss_tex2D(highp vec2 uv)
 {
-    return texture2D(tex, uv, -1.0);
+    return texture2D(texture_sampler, uv, -1.0);
 }
 #endif
 
 void main()
 {
-    mediump vec4 tex = rgss_tex2D(texture_sampler, var_texcoord0.xy);
+    mediump vec4 tex = rgss_tex2D(var_texcoord0.xy);
     gl_FragColor = tex * var_color;
 }

--- a/sharp_sprite/rgss_bias/materials/particlefx.fp
+++ b/sharp_sprite/rgss_bias/materials/particlefx.fp
@@ -16,17 +16,17 @@ const mediump vec2 rgss_uv_offsets = vec2(0.125, 0.375);
 // - OpenGL ES 3.0, WebGL 2.0.
 // - OpenGL ES 2.0, WebGL 1.0, if the extension GL_OES_standard_derivatives is enabled.
 #if !defined(GL_ES) || __VERSION__ >= 300 || defined(GL_OES_standard_derivatives)
-mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
+mediump vec4 rgss_tex2D(highp vec2 uv)
 {
     // Per pixel partial derivatives
     mediump vec2 dx = dFdx(uv);
     mediump vec2 dy = dFdy(uv);
 
     // Supersampled using 2x2 rotated grid
-    mediump vec4 col = texture2D(tex, vec2(uv + rgss_uv_offsets.x * dx + rgss_uv_offsets.y * dy), -1.0);
-    col += texture2D(tex, vec2(uv - rgss_uv_offsets.x * dx - rgss_uv_offsets.y * dy), -1.0);
-    col += texture2D(tex, vec2(uv + rgss_uv_offsets.y * dx - rgss_uv_offsets.x * dy), -1.0);
-    col += texture2D(tex, vec2(uv - rgss_uv_offsets.y * dx + rgss_uv_offsets.x * dy), -1.0);
+    mediump vec4 col = texture2D(texture_sampler, vec2(uv + rgss_uv_offsets.x * dx + rgss_uv_offsets.y * dy), -1.0);
+    col += texture2D(texture_sampler, vec2(uv - rgss_uv_offsets.x * dx - rgss_uv_offsets.y * dy), -1.0);
+    col += texture2D(texture_sampler, vec2(uv + rgss_uv_offsets.y * dx - rgss_uv_offsets.x * dy), -1.0);
+    col += texture2D(texture_sampler, vec2(uv - rgss_uv_offsets.y * dx + rgss_uv_offsets.x * dy), -1.0);
 
     col *= 0.25;
 
@@ -34,9 +34,9 @@ mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
 }
 #else
 // A fallback in the case of derivatives lack
-mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
+mediump vec4 rgss_tex2D(highp vec2 uv)
 {
-    return texture2D(tex, uv, -1.0);
+    return texture2D(texture_sampler, uv, -1.0);
 }
 #endif
 
@@ -45,5 +45,5 @@ void main()
     // Pre-multiply alpha since all runtime textures already are
     mediump vec4 tint_pm = vec4(tint.xyz * tint.w, tint.w);
     // var_color is vertex color from the particle system, pre-multiplied in vertex program
-    gl_FragColor = rgss_tex2D(texture_sampler, var_texcoord0.xy) * var_color * tint_pm;
+    gl_FragColor = rgss_tex2D(var_texcoord0.xy) * var_color * tint_pm;
 }

--- a/sharp_sprite/rgss_bias/materials/spine.fp
+++ b/sharp_sprite/rgss_bias/materials/spine.fp
@@ -16,17 +16,17 @@ uniform mediump vec4 tint;
 // Rotated grid UV offsets
 const mediump vec2 rgss_uv_offsets = vec2(0.125, 0.375);
 
-mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
+mediump vec4 rgss_tex2D(highp vec2 uv)
 {
     // Per pixel partial derivatives
     mediump vec2 dx = dFdx(uv);
     mediump vec2 dy = dFdy(uv);
 
     // Supersampled using 2x2 rotated grid
-    mediump vec4 col = texture2D(tex, vec2(uv + rgss_uv_offsets.x * dx + rgss_uv_offsets.y * dy), -1.0);
-    col += texture2D(tex, vec2(uv - rgss_uv_offsets.x * dx - rgss_uv_offsets.y * dy), -1.0);
-    col += texture2D(tex, vec2(uv + rgss_uv_offsets.y * dx - rgss_uv_offsets.x * dy), -1.0);
-    col += texture2D(tex, vec2(uv - rgss_uv_offsets.y * dx + rgss_uv_offsets.x * dy), -1.0);
+    mediump vec4 col = texture2D(texture_sampler, vec2(uv + rgss_uv_offsets.x * dx + rgss_uv_offsets.y * dy), -1.0);
+    col += texture2D(texture_sampler, vec2(uv - rgss_uv_offsets.x * dx - rgss_uv_offsets.y * dy), -1.0);
+    col += texture2D(texture_sampler, vec2(uv + rgss_uv_offsets.y * dx - rgss_uv_offsets.x * dy), -1.0);
+    col += texture2D(texture_sampler, vec2(uv - rgss_uv_offsets.y * dx + rgss_uv_offsets.x * dy), -1.0);
 
     col *= 0.25;
 
@@ -34,9 +34,9 @@ mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
 }
 #else
 // A fallback in the case of derivatives lack
-mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
+mediump vec4 rgss_tex2D(highp vec2 uv)
 {
-    return texture2D(tex, uv, -1.0);
+    return texture2D(texture_sampler, uv, -1.0);
 }
 #endif
 
@@ -45,5 +45,5 @@ void main()
     // Pre-multiply alpha since var_color and all runtime textures already are
     mediump vec4 tint_pm = vec4(tint.xyz * tint.w, tint.w);
     mediump vec4 color_pm = var_color * tint_pm;
-    gl_FragColor = rgss_tex2D(texture_sampler, var_texcoord0.xy) * color_pm;
+    gl_FragColor = rgss_tex2D(var_texcoord0.xy) * color_pm;
 }

--- a/sharp_sprite/rgss_bias/materials/sprite.fp
+++ b/sharp_sprite/rgss_bias/materials/sprite.fp
@@ -15,17 +15,17 @@ uniform mediump vec4 tint;
 // Rotated grid UV offsets
 const mediump vec2 rgss_uv_offsets = vec2(0.125, 0.375);
 
-mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
+mediump vec4 rgss_tex2D(highp vec2 uv)
 {
     // Per pixel partial derivatives
     mediump vec2 dx = dFdx(uv);
     mediump vec2 dy = dFdy(uv);
 
     // Supersampled using 2x2 rotated grid
-    mediump vec4 col = texture2D(tex, vec2(uv + rgss_uv_offsets.x * dx + rgss_uv_offsets.y * dy), -1.0);
-    col += texture2D(tex, vec2(uv - rgss_uv_offsets.x * dx - rgss_uv_offsets.y * dy), -1.0);
-    col += texture2D(tex, vec2(uv + rgss_uv_offsets.y * dx - rgss_uv_offsets.x * dy), -1.0);
-    col += texture2D(tex, vec2(uv - rgss_uv_offsets.y * dx + rgss_uv_offsets.x * dy), -1.0);
+    mediump vec4 col = texture2D(texture_sampler, vec2(uv + rgss_uv_offsets.x * dx + rgss_uv_offsets.y * dy), -1.0);
+    col += texture2D(texture_sampler, vec2(uv - rgss_uv_offsets.x * dx - rgss_uv_offsets.y * dy), -1.0);
+    col += texture2D(texture_sampler, vec2(uv + rgss_uv_offsets.y * dx - rgss_uv_offsets.x * dy), -1.0);
+    col += texture2D(texture_sampler, vec2(uv - rgss_uv_offsets.y * dx + rgss_uv_offsets.x * dy), -1.0);
 
     col *= 0.25;
 
@@ -33,9 +33,9 @@ mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
 }
 #else
 // A fallback in the case of derivatives lack
-mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
+mediump vec4 rgss_tex2D(highp vec2 uv)
 {
-    return texture2D(tex, uv, -1.0);
+    return texture2D(texture_sampler, uv, -1.0);
 }
 #endif
 
@@ -43,5 +43,5 @@ void main()
 {
     // Pre-multiply alpha since all runtime textures already are
     mediump vec4 tint_pm = vec4(tint.xyz * tint.w, tint.w);
-    gl_FragColor = rgss_tex2D(texture_sampler, var_texcoord0.xy) * tint_pm;
+    gl_FragColor = rgss_tex2D(var_texcoord0.xy) * tint_pm;
 }

--- a/sharp_sprite/rgss_bias/materials/tile_map.fp
+++ b/sharp_sprite/rgss_bias/materials/tile_map.fp
@@ -15,17 +15,17 @@ uniform mediump vec4 tint;
 // Rotated grid UV offsets
 const mediump vec2 rgss_uv_offsets = vec2(0.125, 0.375);
 
-mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
+mediump vec4 rgss_tex2D(highp vec2 uv)
 {
     // Per pixel partial derivatives
     mediump vec2 dx = dFdx(uv);
     mediump vec2 dy = dFdy(uv);
 
     // Supersampled using 2x2 rotated grid
-    mediump vec4 col = texture2D(tex, vec2(uv + rgss_uv_offsets.x * dx + rgss_uv_offsets.y * dy), -1.0);
-    col += texture2D(tex, vec2(uv - rgss_uv_offsets.x * dx - rgss_uv_offsets.y * dy), -1.0);
-    col += texture2D(tex, vec2(uv + rgss_uv_offsets.y * dx - rgss_uv_offsets.x * dy), -1.0);
-    col += texture2D(tex, vec2(uv - rgss_uv_offsets.y * dx + rgss_uv_offsets.x * dy), -1.0);
+    mediump vec4 col = texture2D(texture_sampler, vec2(uv + rgss_uv_offsets.x * dx + rgss_uv_offsets.y * dy), -1.0);
+    col += texture2D(texture_sampler, vec2(uv - rgss_uv_offsets.x * dx - rgss_uv_offsets.y * dy), -1.0);
+    col += texture2D(texture_sampler, vec2(uv + rgss_uv_offsets.y * dx - rgss_uv_offsets.x * dy), -1.0);
+    col += texture2D(texture_sampler, vec2(uv - rgss_uv_offsets.y * dx + rgss_uv_offsets.x * dy), -1.0);
 
     col *= 0.25;
 
@@ -33,9 +33,9 @@ mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
 }
 #else
 // A fallback in the case of derivatives lack
-mediump vec4 rgss_tex2D(mediump sampler2D tex, highp vec2 uv)
+mediump vec4 rgss_tex2D(highp vec2 uv)
 {
-    return texture2D(tex, uv, -1.0);
+    return texture2D(texture_sampler, uv, -1.0);
 }
 #endif
 
@@ -43,5 +43,5 @@ void main()
 {
     // Pre-multiply alpha since all runtime textures already are
     mediump vec4 tint_pm = vec4(tint.xyz * tint.w, tint.w);
-    gl_FragColor = rgss_tex2D(texture_sampler, var_texcoord0.xy) * tint_pm;
+    gl_FragColor = rgss_tex2D(var_texcoord0.xy) * tint_pm;
 }


### PR DESCRIPTION
Fix for build error in Defold 1.9.4

```
The build failed for the following reasons:
ERROR sharp_sprite/rgss/fonts/font-singlelayer.fp build/default/sharp_sprite/rgss/fonts/font-singlelayer.fpc: /var/folders/11/46kfq53d3qg84mb4gjdm5hk40000gn/T/font-singlelayer.fpc17412910706288072366.glsl:50: 'rgss_tex2D' : no matching overloaded function found
ERROR: /var/folders/11/46kfq53d3qg84mb4gjdm5hk40000gn/T/font-singlelayer.fpc17412910706288072366.glsl:50: '=' :  cannot convert from ' const float' to ' temp lowp 2-component vector of float'
ERROR: /var/folders/11/46kfq53d3qg84mb4gjdm5hk40000gn/T/font-singlelayer.fpc17412910706288072366.glsl:50: '' : compilation terminated
ERROR: 3 compilation errors.  No code generated.
```

Note: There should probably be a fix in the shader compiler in Defold.